### PR TITLE
Depend on ign-utils1

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -10,6 +10,7 @@ Build-Depends: cmake,
                libfreeimage-dev,
                libignition-cmake2-dev,
                libignition-math6-dev,
+               libignition-utils-dev,
                libtinyxml2-dev,
                uuid-dev,
                libgts-dev,
@@ -38,6 +39,7 @@ Package: libignition-common4-core-dev
 Architecture: any
 Section: libdevel
 Depends: libignition-cmake2-dev,
+         libignition-utils-dev,
          uuid-dev,
          libignition-common4 (= ${binary:Version}),
          ${misc:Depends}
@@ -85,6 +87,7 @@ Architecture: any
 Section: libdevel
 Depends: libignition-cmake2-dev,
          libignition-common4-core-dev,
+         libignition-utils-dev,
          libavdevice-dev,
          libavformat-dev,
          libavcodec-dev,
@@ -120,6 +123,7 @@ Architecture: any
 Section: libdevel
 Depends: libignition-cmake2-dev,
          libignition-common4-core-dev,
+         libignition-utils-dev,
          libignition-math6-dev,
          libignition-common4-events (= ${binary:Version}),
          ${misc:Depends}
@@ -152,6 +156,7 @@ Section: libdevel
 Depends: libignition-cmake2-dev,
          libignition-common4-core-dev,
          libignition-math6-dev,
+         libignition-utils-dev,
          libtinyxml2-dev,
          libgts-dev,
          libignition-common4-graphics (= ${binary:Version}),


### PR DESCRIPTION
Part of [ign-common #161](https://github.com/ignitionrobotics/ign-common/issues/161)

Technically as of now only `libignition-common4-graphics-dev` depends on ign-utils but I added the dependency to all packages that have data pointers (all except `libignition-common4-profiler-dev`) so we won't need to come back and update the dependencies of the subpackages when they are also updated.