### PR TITLE
Require component -dev packages use same version

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -55,11 +55,11 @@ Description: Ignition Common classes and functions (core) - Development files
 Package: libignition-common4-dev
 Architecture: any
 Section: libdevel
-Depends: libignition-common4-core-dev,
-         libignition-common4-av-dev,
-	 libignition-common4-events-dev,
-	 libignition-common4-graphics-dev,
-	 libignition-common4-profiler-dev,
+Depends: libignition-common4-core-dev (= ${binary:Version}),
+         libignition-common4-av-dev (= ${binary:Version}),
+         libignition-common4-events-dev (= ${binary:Version}),
+         libignition-common4-graphics-dev (= ${binary:Version}),
+         libignition-common4-profiler-dev (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same
 Description: Ignition Common classes and functions for robot apps - Metapackage
@@ -86,7 +86,7 @@ Package: libignition-common4-av-dev
 Architecture: any
 Section: libdevel
 Depends: libignition-cmake2-dev,
-         libignition-common4-core-dev,
+         libignition-common4-core-dev (= ${binary:Version}),
          libignition-utils1-dev,
          libavdevice-dev,
          libavformat-dev,
@@ -122,7 +122,7 @@ Package: libignition-common4-events-dev
 Architecture: any
 Section: libdevel
 Depends: libignition-cmake2-dev,
-         libignition-common4-core-dev,
+         libignition-common4-core-dev (= ${binary:Version}),
          libignition-utils1-dev,
          libignition-math6-dev,
          libignition-common4-events (= ${binary:Version}),
@@ -154,7 +154,7 @@ Package: libignition-common4-graphics-dev
 Architecture: any
 Section: libdevel
 Depends: libignition-cmake2-dev,
-         libignition-common4-core-dev,
+         libignition-common4-core-dev (= ${binary:Version}),
          libignition-math6-dev,
          libignition-utils1-dev,
          libtinyxml2-dev,
@@ -188,7 +188,7 @@ Package: libignition-common4-profiler-dev
 Architecture: any
 Section: libdevel
 Depends: libignition-cmake2-dev,
-         libignition-common4-core-dev,
+         libignition-common4-core-dev (= ${binary:Version}),
          libignition-common4-profiler (= ${binary:Version}),
          ${misc:Depends}
 Breaks: libignition-common4-dev (<< 3.0.0~pre5+hg20190228r1b2df90990)


### PR DESCRIPTION
This is the same changes as https://github.com/ignition-release/ign-common3-release/pull/1 as part of https://github.com/ignition-tooling/release-tools/issues/469